### PR TITLE
Fixed some typos in the documentation

### DIFF
--- a/documentation.tex
+++ b/documentation.tex
@@ -324,7 +324,7 @@ Copyright \textcopyright\ \texttt{Florian Sihler}. Permission is granted to copy
 The shown example penguins are purely fictional characters, any resemblance to real penguins or real persons is purely coincidental and no copyright infringement is intended.
 
 \subsection{Libraries}
-With Version $1.1$ I've split the penguin features into a set of libraries.
+With Version $1.1$, I've split the penguin features into a set of libraries.
 To stay backwards compatible, all of them are loaded by default so nothing changes when using tikzpingus. However, the |bare| package-option disables the automatic loading of all libraries. They can be loaded (locally to the current group) using |\pinguloadlibrary| and |\pinguloadlibraries| passing on a comma separated list of desired libraries.
 At the moment, there are the following libraries:
 {\newif\iffirstss\begin{description}
@@ -453,7 +453,7 @@ body types can change the coordinates (left the \keyref{body type} \textit{chubb
 \end{center}
 
 \subsection{Colors}
-A lot of options allow for a color to passed. In general, you can provide any color that \TikZ\ is happy with! Yet, there are some predefined pingu-colors shipped with this package, and there is one special \say{color}:
+A lot of options allow for a color to be passed. In general, you can provide any color that \TikZ\ is happy with! Yet, there are some predefined pingu-colors shipped with this package, and there is one special \say{color}:
 \begin{multicols}{4}
 \begin{itemize}
 	\itemsep0pt
@@ -644,7 +644,7 @@ I am working on the \textit{cloak}-Clothing at the moment:
 	\textit{Please note, that all preview-penguins have been reduced in scale by \(40\,\%\) to save space and make the documentation more concise.}
 \end{center}
 
-Aliases my set custom defaults. Those defaults are not listed as they may change.
+Aliases may set custom defaults. Those defaults are not listed as they may change.
 
 \def\lstfnsize{-1.65}
 \tcbset{%


### PR DESCRIPTION
I've fixed some typos in the documentation (every typo I've found so far, until section 3, Examples).
By now, they are only fixed in the .tex-file, the documentation pdf hasn't changed.