### PR TITLE
fix keyval specs in documentation

### DIFF
--- a/doc/tikzpingus-doc.tex
+++ b/doc/tikzpingus-doc.tex
@@ -2732,7 +2732,7 @@ Change the color of the cake hats' outline (width by \keyref{cake-hat outline wi
 \end{tcblisting}
 \endsubkeyexplain}
 
-\subkeyexplain{cake-hat}{cake-hat outline width}{color}{\pingu@x@cakehat@outline@w}
+\subkeyexplain{cake-hat}{cake-hat outline width}{length}{\pingu@x@cakehat@outline@w}
 Change the width of the cake hats' outline (color by \keyref{cake-hat outline}):
 \begin{tcblisting}{@}
 \begin{tikzpicture}
@@ -2814,7 +2814,7 @@ Change the color of the third stripe:
 \end{tcblisting}
 \endsubkeyexplain
 
-\subkeyexplain{pumpkin-hat}{pumpkin-hat outline width}{color}{\pingu@x@pumpkinhat@outline@w}
+\subkeyexplain{pumpkin-hat}{pumpkin-hat outline width}{length}{\pingu@x@pumpkinhat@outline@w}
 \begin{tcblisting}{@}
 \begin{tikzpicture}
 	\pingu[pumpkin-hat,pumpkin-hat outline width=3pt]
@@ -4439,7 +4439,7 @@ By default, the left horse will be flipped. The right horse won't.
 \end{tcblisting}
 \endsubkeyexplain
 
-\subkeyexplain{horse left}{horse left xshift}{color}{\pingu@x@horseleft@xshift}
+\subkeyexplain{horse left}{horse left xshift}{length}{\pingu@x@horseleft@xshift}
 This key reacts with the \keyref{horse left flip} option!
 \begin{tcblisting}{@}
 \begin{tikzpicture}
@@ -4448,7 +4448,7 @@ This key reacts with the \keyref{horse left flip} option!
 \end{tcblisting}
 \endsubkeyexplain
 
-\subkeyexplain{horse left}{horse left yshift}{color}{\pingu@x@horseleft@yshift}
+\subkeyexplain{horse left}{horse left yshift}{length}{\pingu@x@horseleft@yshift}
 \begin{tcblisting}{@}
 \begin{tikzpicture}
 	\pingu[horse left,horse left yshift=1cm]


### PR DESCRIPTION
A few length keys had "color" as their listed arg type, which I went ahead and fixed.