### PR TITLE
warning for too small penguins

### DIFF
--- a/examples/minimal.tex
+++ b/examples/minimal.tex
@@ -24,7 +24,7 @@
    \pingu[body=patron,body front=patron,feet color=patron, bill color=patron,eyes color=patron,wings wave,devil wings=patron,left eye devil,left eye second color=patron]
 \end{tikzpicture}}}\copy0\kern\dimexpr-.5\wd0-6mm\relax%
 {\smash{\raisebox{3pt}{\clap{\begin{tikzpicture}
-   \pingu[body=pingu@black,horse right=tino-brown, horse right mane=tino-hair, devil horns=pingu@black!80!pingu@white,eyes shiny,left wing grab, blush,tie=pink, body type=legacy,feet sit,height=9.5mm,right wing hug,right item angle=25]
+   \pingu[body=pingu@black,horse right=tino-brown, horse right mane=tino-hair, devil horns=pingu@black!80!pingu@white,eyes shiny,left wing grab, blush,tie=pink, body type=legacy,feet sit,height=10.33mm,right wing hug,right item angle=25]
 \end{tikzpicture}}}}}\kern\dimexpr.5\wd0+6mm\relax}%
 \end{preview}
 \end{document}

--- a/tex/tikzpingus.sty
+++ b/tex/tikzpingus.sty
@@ -301,6 +301,7 @@
 \ifpengu@setup@manual@layers@\pgfsetlayers{background,main,middle,foreground}\fi\begingroup
 \@pingu@do@back@false
 \pgfqkeys{/pingu}{defaults, #1}%
+\ifdim\pingu@side@h@half<10.33mm \PackageWarning{\tikzpingus@filename}{Penguins with a height below 10.33mm may have unwanted artifacts.}\fi
 \scope[/pingu/@pingu,/pingu/@pingu@main]
 \@pingu@drawer@bodytype@
 \pingu@body@app


### PR DESCRIPTION
Using `\PackageWarning` to guard against too small penguins.