### PR TITLE
doc: minor spacing and typo

### DIFF
--- a/doc/tikzpingus-doc.tex
+++ b/doc/tikzpingus-doc.tex
@@ -337,7 +337,7 @@
 	 \node[above=3mm,font=\bfseries\sffamily\Large] at(current bounding box.north) {Motivation};
 \end{tikzpicture}\vspace*{-\baselineskip}
 \end{center}
-\footnotetext{Why \say{pingu} and not \say{pengu}? Well, this is the third try on achieving cute penguins without using any templates or vector formats as a basis. As a german, the short form \say{pingu} was merely a typo that originated from the german word \say{pinguin} for \say{penguin}. It somewhat sticked\ldots}
+\footnotetext{Why \say{pingu} and not \say{pengu}? Well, this is the third try on achieving cute penguins without using any templates or vector formats as a basis. As a German, the short form \say{pingu} was merely a typo that originated from the German word \say{pinguin} for \say{penguin}. It somewhat stuck\ldots}
 \endgroup\vfill
 
 \begin{center}

--- a/doc/tikzpingus-doc.tex
+++ b/doc/tikzpingus-doc.tex
@@ -406,7 +406,7 @@
 \subsection{Dependencies}
 
 As this package is constantly work in progress, the concrete dependencies may change any time.
-At the moment, it loads \href{https://www.ctan.org/pkg/pgf}{\TikZ}, which loads a lot of other packages (e.g. \href{https://www.ctan.org/pkg/xcolor}{xcolor}), and \href{https://www.ctan.org/pkg/etoolbox}{etoolbox}.
+At the moment, it loads \href{https://www.ctan.org/pkg/pgf}{\TikZ}, which loads a lot of other packages (e.g.\ \href{https://www.ctan.org/pkg/xcolor}{xcolor}), and \href{https://www.ctan.org/pkg/etoolbox}{etoolbox}.
 Furthermore, the following \TikZ-Libraries are in use:\footnote{A lot of the libraries loaded are important only for specific extras. I plan on cleaning them up.} \textit{intersections}, \textit{shadings}, \textit{patterns.meta}, \textit{decorations.pathmorphing}, and \textit{shapes.symbols}.
 
 \subsection{Copyright}
@@ -964,7 +964,7 @@ Aliases may set custom defaults. Those defaults are not listed as they may chang
 
 
 \keyexplain{left eye second color}{color}{\pingu@color@eye@second@left}
-	Change the secondary color of the left eye. It will be used in some styles selected by \keyref{left eye} (e.g. \textit{shiny}):
+	Change the secondary color of the left eye. It will be used in some styles selected by \keyref{left eye} (e.g.\ \textit{shiny}):
 \begin{tcblisting}{listing options={style=lstpingu,language=pingulang,deleteemph={[2]{shiny}}}}
 \begin{tikzpicture}
 	\pingu[left eye=shiny,
@@ -995,7 +995,7 @@ Aliases may set custom defaults. Those defaults are not listed as they may chang
 
 
 \keyexplain{right eye second color}{color}{\pingu@color@eye@second@right}
-	Change the secondary color of the right eye. It will be used in some styles selected by \keyref{right eye} (e.g. \textit{shiny}):
+	Change the secondary color of the right eye. It will be used in some styles selected by \keyref{right eye} (e.g.\ \textit{shiny}):
 \begin{tcblisting}{listing options={style=lstpingu,language=pingulang,deleteemph={[2]{shock}}}}
 \begin{tikzpicture}
 	\pingu[right eye=shock,
@@ -3223,7 +3223,7 @@ Change the bending of the banner:
 
 
 \keyexplain{left wing item flip}{true/false}{\if@pingu@wi@flip@left true\else false\fi}
-	Some \hyperref[sub:wing-items]{wing items} do have a different style, depending on the wing they are in (e.g. they are mirrored). This option toggles the stile for the left wing.
+	Some \hyperref[sub:wing-items]{wing items} do have a different style, depending on the wing they are in (e.g.\ they are mirrored). This option toggles the stile for the left wing.
 \begin{tcblisting}{@}
 \begin{tikzpicture}
 	\pingu[flag left, flag right,
@@ -3249,7 +3249,7 @@ Change the bending of the banner:
 
 
 \keyexplain{right wing item flip}{true/false}{\if@pingu@wi@flip@right true\else false\fi}
-	Some \hyperref[sub:wing-items]{wing items} do have a different style, depending on the wing they are in (e.g. they are mirrored). This option toggles the stile for the right wing.
+	Some \hyperref[sub:wing-items]{wing items} do have a different style, depending on the wing they are in (e.g.\ they are mirrored). This option toggles the stile for the right wing.
 \begin{tcblisting}{@}
 \begin{tikzpicture}
 	\pingu[flag left, flag right,


### PR DESCRIPTION
Old spacing after `e.g.` bottom, new spacing top:

![Screenshot 2022-08-30 at 15 42 24](https://user-images.githubusercontent.com/43832342/187452903-43716a92-aa96-47f6-a9ba-f366c79401e3.png)
